### PR TITLE
Derive build arch from compiler, not uname -m

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,12 @@ if [ "$CLEAN"x == "restorex" ]; then
 	exit 0
 fi
 
-case $(uname -m) in
+# Determine the target architecture from the compiler rather than `uname -m`.
+# On the Windows/ARM64 runner the MSYS `uname` is an x86_64 binary running under
+# emulation and reports x86_64, which would misname the arm64 library. Querying
+# the compiler (honoring an externally-provided CC, e.g. aarch64-w64-mingw32-gcc)
+# yields the real target triple.
+case $(${CC:-gcc} -dumpmachine) in
 x86_64*|amd64*)
 	ARCH=amd64
 	;;


### PR DESCRIPTION
## Problem

The `libmupdf_windows_arm64.tar.gz` release asset contains a file named `libmupdf_windows_amd64.a` that actually holds **ARM64** code, and no `libmupdf_windows_arm64.a` is produced at all.

Root cause is in `build.sh`. The library filename is built from an architecture detected via `uname -m`:

```bash
case $(uname -m) in
x86_64*|amd64*)  ARCH=amd64 ;;
aarch64*|arm64*) ARCH=arm64 ;;
esac
...
ar -r libmupdf_${OS_TYPE}_${ARCH}.a ...
```

On the `windows-11-arm` runner, `release.yml` correctly installs a native `aarch64-w64-mingw32` toolchain and sets `CC`, so the compiled code is genuinely ARM64. But the MSYS/Git-Bash `uname` on that runner is itself an x86_64 binary running under emulation, so `uname -m` returns `x86_64` → `ARCH=amd64`, and the arm64 build is named `libmupdf_windows_amd64.a`.

Meanwhile `release.yml` names the *archive* from `$RUNNER_ARCH` (correctly `arm64`), yielding `libmupdf_windows_arm64.tar.gz` whose contents are mislabeled. Verified by reading the COFF machine field: the arm64 tarball's objects are `0xAA64` (ARM64), the amd64 tarball's are `0x8664` (x86-64). Consumers that unpack by the internal `.a` name end up with no arm64 lib and a corrupted amd64 one.

## Fix

Derive `ARCH` from the compiler's target triple (`${CC:-gcc} -dumpmachine`) instead of the host `uname -m`. This honors the externally-provided `CC` and reflects what's actually being built. Verified the parsing across all six triples:

| triple | ARCH |
|---|---|
| `x86_64-w64-mingw32` | amd64 |
| `aarch64-w64-mingw32` | arm64 |
| `x86_64-apple-darwin*` | amd64 |
| `arm64-apple-darwin*` | arm64 |
| `x86_64-linux-gnu` | amd64 |
| `aarch64-linux-gnu` | arm64 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)